### PR TITLE
Fixed cookies + better "ready" handler + viewport masking + docs + misc other fixes...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-MINIFY = uglifyjs --lint
+MINIFY = uglifyjs --lint -c -m toplevel=true
 LINT = jshint --show-non-errors
 UPLOAD = s3cmd put -P
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ style. The following options are settable through a `data-` property on the
 * `moreinfo` - where the visitor can read more about cookies
   (default: [http://aboutcookies.org](http://aboutcookies.org))
 
+* `mask` - whether to create a mask over the viewport (default: `false`). Clicking anywhere on the mask is considered as acceptance.
+* `mask-opacity` - the opacity to use for the window mask (default: `0.5`)
+* `mask-background` - optional background style you wish to apply to the `mask` <div> (default: `#000`)
+
+* `zindex` - z-index to set on the notice (default: `255`). If `mask` is used, the notice <div>'s z-index is automatically incremented by 1 so it appears above the mask)
+
 Here's an example:
 
     <script type="text/javascript" id="cookiebanner"
@@ -69,9 +75,9 @@ If the banner needs to be shown, the script will create the following DOM
 subtree and add it just before the closing `</body>` tag:
 
     <div class="cookiebanner">
+        <div style="float: right; padding-left:5px;">x</div>
         <span>Message</span>
-        <a href=".." target="_blank">Learn more</a>
-        <div style="float: right;">x</div>
+        <a href=".." target="_blank">Learn more</a>        
     </div>
 
 You can use CSS with `div.cookiebanner > span` and `div.cookiebanner > a` to
@@ -86,12 +92,12 @@ Get the newest and the freshest from GitHub:
 If you've modified the code, it's recommended you run it through linter
 to catch potential errors, and minifier to minimize its footprint.
 
-We're old-school here so we just use Makfile for the tasks:
+We're old-school here so we just use Makefile for the tasks:
 
     make check  # run jshint to check the code
     make # minify it
 
-You'll need `jshint` and `uglifjs` tools installed for this.
+You'll need `jshint` and `uglifyjs` tools installed for this.
 
 Pull requests are welcome! In order to get your pull-request accepted,
 please follow these simple rules:

--- a/src/cookiebanner.js
+++ b/src/cookiebanner.js
@@ -1,7 +1,7 @@
 /*global window:false*/
 
 (function() {
-    "use strict";
+    'use strict';
 
     var win = window, doc = win.document;
 
@@ -21,13 +21,91 @@
 
     function on(el, ev, fn) { el.addEventListener(ev, fn, false); }
 
-    function onReady(fn) {
-        on(doc, 'readystatechange', function() {
-            if (doc.readyState == 'complete') fn();
-        });
-    }
+    /*!
+     * contentloaded.js
+     *
+     * Author: Diego Perini (diego.perini at gmail.com)
+     * Summary: cross-browser wrapper for DOMContentLoaded
+     * Updated: 20101020
+     * License: MIT
+     * Version: 1.2
+     *
+     * URL:
+     * http://javascript.nwbox.com/ContentLoaded/
+     * http://javascript.nwbox.com/ContentLoaded/MIT-LICENSE
+     *
+     */
+    // @win window reference
+    // @fn function reference
+    function contentLoaded(win, fn) {
 
-    function getScriptData(key, dfl) {
+        var done = false, top = true,
+        doc = win.document, root = doc.documentElement,
+
+        add = doc.addEventListener ? 'addEventListener' : 'attachEvent',
+        rem = doc.addEventListener ? 'removeEventListener' : 'detachEvent',
+        pre = doc.addEventListener ? '' : 'on',
+
+        init = function(e) {
+            if (e.type == 'readystatechange' && doc.readyState != 'complete') return;
+            (e.type == 'load' ? win : doc)[rem](pre + e.type, init, false);
+            if (!done && (done = true)) fn.call(win, e.type || e);
+        },
+
+        poll = function() {
+            try { root.doScroll('left'); } catch(e) { setTimeout(poll, 50); return; }
+            init('poll');
+        };
+
+        if (doc.readyState == 'complete') fn.call(win, 'lazy');
+        else {
+            if (doc.createEventObject && root.doScroll) {
+                try { top = !win.frameElement; } catch(e) { }
+                if (top) poll();
+            }
+            doc[add](pre + 'DOMContentLoaded', init, false);
+            doc[add](pre + 'readystatechange', init, false);
+            win[add](pre + 'load', init, false);
+        }
+
+    }
+    
+    var Cookies = {
+        get: function (key) {
+            return decodeURIComponent(doc.cookie.replace(new RegExp('(?:(?:^|.*;)\\s*' + encodeURIComponent(key).replace(/[\-\.\+\*]/g, '\\$&') + '\\s*\\=\\s*([^;]*).*$)|^.*$'), '$1')) || null;
+        },
+        set: function (key, val, end, path, domain, secure) {
+            if (!key || /^(?:expires|max\-age|path|domain|secure)$/i.test(key)) {
+                return false;
+            }
+            var expires = '';
+            if (end) {
+                switch (end.constructor) {
+                    case Number:
+                        expires = end === Infinity ? '; expires=Fri, 31 Dec 9999 23:59:59 GMT' : '; max-age=' + end;
+                        break;
+                    case String:
+                        expires = '; expires=' + end;
+                    break;
+                    case Date:
+                        expires = '; expires=' + end.toUTCString();
+                    break;
+                }
+            }
+            doc.cookie = encodeURIComponent(key) + '=' + encodeURIComponent(val) + expires + (domain ? '; domain=' + domain : '') + (path ? '; path=' + path : '') + (secure ? '; secure' : '');
+            return true;
+        },
+        has: function (key) {
+            return (new RegExp('(?:^|;\\s*)' + encodeURIComponent(key).replace(/[\-\.\+\*]/g, '\\$&') + '\\s*\\=')).test(doc.cookie);
+        }
+        /*remove: function (key, path, domain) {
+            if (!key || !this.has(key)) { return false; }
+            doc.cookie = encodeURIComponent(sKey) + '=; expires=Thu, 01 Jan 1970 00:00:00 GMT' + ( domain ? '; domain=' + domain : '') + ( path ? '; path=' + path : '');
+            return true;
+        },*/
+    };
+
+    function get_script_data(key, dfl) {
         var val;
 
         if (script.hasOwnProperty('dataset')) {
@@ -40,83 +118,120 @@
         if (val === undefined) val = dfl;
         return val;
     }
-
-    function getCookie() {
-        var cookie_name = getScriptData('cookie', 'cookiebanner-accepted');
-
-        var cookies = doc.cookie.split(/;\s+/);
-        for (var i = 0; i < cookies.length; i++) {
-            var pair = cookies[i].split('=');
-            if (pair[0] == cookie_name) {
+    
+    function str2bool(str) {
+        str = '' + str;
+        switch (str.toLowerCase()) {
+            case 'false':
+            case 'no':
+            case '0':
+            case '':
+                return false; 
+            default: 
                 return true;
             }
+    }
+    
+    function fade_in(el) {
+        if (el.style.opacity < 1) {
+            el.style.opacity = (parseFloat(el.style.opacity) + 0.05).toFixed(2);
+            win.setTimeout(function(){
+                fade_in(el);
+            }, 50);
         }
-        return false;
     }
 
-    function setCookie() {
-        var cookie_name = getScriptData('cookie', 'cookiebanner-accepted');
-        doc.cookie = cookie_name + "=true";
+    var cookie_name = get_script_data('cookie', 'cookiebanner-accepted');
+    var z_idx = parseInt(get_script_data('zindex', 255), 10);   
+
+    function build_viewport_mask() {
+        var create_mask = str2bool(get_script_data('mask', false));
+        var mask = null;
+        if (true === create_mask) {
+            var mask_opacity = get_script_data('mask-opacity', 0.5);
+            var bg = get_script_data('mask-background', '#000');
+            var mask_markup = '<div id="cookiebanner-mask" style="' +
+                'position:fixed;top:0;left:0;width:100%;height:100%;' + 
+                'background:' + bg + ';zoom:1;filter:alpha(opacity=' + 
+                (mask_opacity * 100) +');opacity:' + mask_opacity +';' +
+                'z-index:' + z_idx +';"></div>';
+            var el = doc.createElement('div');
+            el.innerHTML = mask_markup;
+            mask = el.firstChild;
+        }
+        return mask;
     }
 
-    function show_el() {
+    function inject_notice() {
+
+        var mask = build_viewport_mask();
+        if (mask) {
+            // bump notice element's z-index so it's above the mask
+            z_idx += 1;
+        }
+
         var el = doc.createElement('div');
-        el['class'] = "cookiebanner";
-        el.style.position = "fixed";
+        el.className = 'cookiebanner';
+        el.style.position = 'fixed';
         el.style.left = 0;
         el.style.right = 0;
-        el.style.height = getScriptData('height', 'auto');
-        el.style.minHeight = getScriptData('min-height', '21px');
-        el.style.zIndex = 255;
-        el.style.background = getScriptData('bg', '#000');
-        el.style.color = getScriptData('fg', '#ddd');
+        el.style.height = get_script_data('height', 'auto');
+        el.style.minHeight = get_script_data('min-height', '21px');
+        el.style.zIndex = z_idx;
+        el.style.background = get_script_data('bg', '#000');
+        el.style.color = get_script_data('fg', '#ddd');
         el.style.lineHeight = el.style.minHeight;
         el.style.padding = '5px 16px';
-        el.style.fontFamily = "arial, sans-serif";
+        el.style.fontFamily = 'arial, sans-serif';
         el.style.fontSize = '14px';
 
-        if (getScriptData('position', 'bottom') == 'top') {
+        if (get_script_data('position', 'bottom') == 'top') {
             el.style.top = 0;
         } else {
             el.style.bottom = 0;
         }
 
-        el.innerHTML = '<span>' + getScriptData('message', default_text) +
-            ' <a>' + getScriptData('linkmsg', default_link) + '</a></span>' +
-            '<div style="float: right; padding-left: 5px;">&#10006;</div>';
+        el.innerHTML = '<div style="float:right;padding-left:5px;">&#10006;</div>' +
+            '<span>' + get_script_data('message', default_text) +
+            ' <a>' + get_script_data('linkmsg', default_link) + '</a></span>';
 
         var el_a = el.getElementsByTagName('a')[0];
-        el_a.href = getScriptData('moreinfo', 'http://aboutcookies.org/');
+        el_a.href = get_script_data('moreinfo', 'http://aboutcookies.org/');
         el_a.target = '_blank';
         el_a.style.textDecoration = 'none';
-        el_a.style.color = getScriptData('link', '#aaa');
+        el_a.style.color = get_script_data('link', '#aaa');
 
         var el_x = el.getElementsByTagName('div')[0];
-        el_x.style.float = 'right';
         el_x.style.cursor = 'pointer';
+        
+        function agree() {
+            Cookies.set(cookie_name, 1, Infinity, '/');
+            doc.body.removeChild(el);
+            if (mask) {
+                doc.body.removeChild(mask);
+            }
+        }
+        
+        on(el_x, 'click', agree);
+
+        if (mask) {
+            on(mask, 'click', agree);
+            doc.body.appendChild(mask);
+        }
 
         doc.body.appendChild(el);
-
-        if (getScriptData('effect') == 'fade') {
+        
+        if (get_script_data('effect') == 'fade') {
             el.style.opacity = 0;
-            var fadeIn = function() {
-                if (el.style.opacity < 1) {
-                    el.style.opacity = parseFloat(el.style.opacity) + 0.05;
-                    win.setTimeout(fadeIn, 50);
-                }
-            };
-            fadeIn();
+            fade_in(el);
         } else {
             el.style.opacity = 1;
         }
 
-        on(el_x, 'click', function() {
-            setCookie();
-            doc.body.removeChild(el);
-        });
     }
 
-    if (!getCookie()) {
-        onReady(show_el);
+    if (!Cookies.has(cookie_name)) {
+        contentLoaded(win, inject_notice);
     }
+
 })();


### PR DESCRIPTION
- new cookie handler has proper support for setting expiry/path/domain/secure parameters + key/value encoding. The old one was not setting the cookie path, so even if you first came to http://goodcode.io/open-source/ and closed/agreed, you were again prompted when you went to the homepage (or any other page with a different path)
- new `contentLoaded()` helps testability and is more generic (works even when the script is injected after everything is already loaded / ready)
- optional covering of the viewport with a mask <div> (clicking on which is treated the same as the 'close/x' button) along with configurable opacity/background
- configurable z-index for the notice (incremented automatically by 1 if a cover is used so that it appears above the cover)
- fixed 'close/x' placement in markup so it looks better on small screens (since it's right-floated, it's better if it comes first in the markup)
- fixed the .cookiebanner className not being set
- shaved another kilobyte off the minified version
