### PR TITLE
Fixed typo on default moreinfo config value

### DIFF
--- a/src/cookiebanner.js
+++ b/src/cookiebanner.js
@@ -207,7 +207,7 @@
                 position: 'bottom',
                 message: default_text,
                 linkmsg: default_link,
-                moreinfo: 'http://aboucookies.org',
+                moreinfo: 'http://aboutcookies.org',
                 effect: null,
                 instance: global_instance_name
             };


### PR DESCRIPTION
There was a typo on the default `moreinfo` link, a `t` character was missing on http://aboutcookies.org
