### PR TITLE
Add typographic options (size and font)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ style. The following options are settable through a `data-` property on the
 * `message` - the message text
 * `linkmsg` - the link text content (default: `Learn more`)
 * `close-text` - the text/symbol for the close button (default: `&#10006;`)
+* `font-size` - the text size of the message and the link (default: `14px`)
+* `font-family` - the font family of the message and the link (default: `arial, sans-serif`)
 * `effect` - effect to use
 * `cookie` - name for the cookie to store the cookiebanner acceptance
   information (default: `cookiebanner-accepted`)

--- a/src/cookiebanner.js
+++ b/src/cookiebanner.js
@@ -238,6 +238,8 @@
                 linkmsg: default_link,
                 moreinfo: 'http://aboutcookies.org',
                 effect: null,
+                fontSize: '14px',
+                fontFamily: 'arial, sans-serif',
                 instance: global_instance_name
             };
 
@@ -386,9 +388,9 @@
             el.style.lineHeight = el.style.minHeight;
 
             el.style.padding = '5px 16px';
-            // TODO: allow typography customizations via data-attribs?
-            el.style.fontFamily = 'arial, sans-serif';
-            el.style.fontSize = '14px';
+
+            el.style.fontFamily = this.options.fontFamily;
+            el.style.fontSize = this.options.fontSize;
 
             if ('top' === this.options.position) {
                 el.style.top = 0;


### PR DESCRIPTION
Allow to customize the font-family and font-size attributes of the banner.
I kept the same defaults as before and added the data-attributes in README.md.
