### PR TITLE
Bunch of fixes which should really be separate commits/branches:

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ style. The following options are settable through a `data-` property on the
 * `position` - banner position, `top` or `bottom` (default: `bottom`)
 * `message` - the message text
 * `linkmsg` - the link text content (default: `Learn more`)
+* `close-text` - the text/symbol for the close button (default: `&#10006;`)
 * `effect` - effect to use
 * `cookie` - name for the cookie to store the cookiebanner acceptance
   information (default: `cookiebanner-accepted`)
@@ -74,13 +75,16 @@ If the banner needs to be shown, the script will create the following DOM
 subtree and add it just before the closing `</body>` tag:
 
     <div class="cookiebanner">
-        <div style="float: right; padding-left:5px;">x</div>
+        <div class="cookiebanner-close" style="float: right; padding-left:5px;">x</div>
         <span>Message</span>
         <a href=".." target="_blank">Learn more</a>
     </div>
 
 You can use CSS with `div.cookiebanner > span` and `div.cookiebanner > a` to
 further modify the banner appearance.
+
+You can also try customizing the close button via the `.cookiebanner-close` CSS class.
+Keep in mind that you might have to override and/or reset certain properties by using `!important` CSS rules.
 
 ## Hacking
 

--- a/tests/demo-minified.html
+++ b/tests/demo-minified.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>cookie-banner simple demo (minifed .js)</title>
+</head>
+<body>
+  <h1 id="qunit-header">cookie-banner simple demo (minified .js)</h1>
+  <script type="text/javascript" id="cookiebanner"
+      src="../src/cookiebanner.min.js"
+      data-height="20px"
+      data-close-text="NOooo!"
+      data-message="We use cookies to improve your browsing experience.">
+  </script>
+</body>
+</html>

--- a/tests/demo.html
+++ b/tests/demo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>cookie-banner simple demo</title>
+</head>
+<body>
+  <h1 id="qunit-header">cookie-banner simple demo</h1>
+  <script type="text/javascript" id="cookiebanner"
+      src="../src/cookiebanner.js"
+      data-height="20px"
+      data-close-text="NOooo!"
+      data-message="We use cookies to improve your browsing experience.">
+  </script>
+</body>
+</html>

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -122,7 +122,9 @@ QUnit.test('Options override / merge', function(assert) {
         linkmsg: 'Testing',
         message: 'Lorem ipsum dolor sit amet...',
         position: 'top',
-        effect: 'fade'
+        effect: 'fade',
+        'close-text': 'Custom close text',
+        'cookie-path': '/non-existing-path/'
     };
     var banner = new Cookiebanner(opts);
 
@@ -159,10 +161,7 @@ QUnit.test('Inserted automatically if called via <script id="cookiebanner"> + cl
 QUnit.test('Not inserted automatically unless called with <script id="cookiebanner"...>', function(assert){
     stop();
     inject_script(script_src, 'different-on-purpose', {}, 'head', function(){
-        assert.ok(window.cbinstance, 'script loaded and window.cbinstance is truthy');
-        assert.ok(!window.cbinstance.inserted, 'window.cbinstance.inserted != true');
-        window.cbinstance.cleanup();
-        assert.strictEqual(undefined, window.cbinstance, 'global window.cbinstance is undefined (meaning cleanup() was successfull)');
+        assert.strictEqual(undefined, window.cbinstance, 'script loaded and window.cbinstance is undefined (meaning we did not instantiate and inject automatically)');
         start();
     });
     remove_el('different-on-purpose');
@@ -183,10 +182,11 @@ if (not_supported) {
     QUnit.test('Called automatically but should not be inserted in the DOM as the cookie should already exist', function(assert){
         var opts = {
             cookie: 'accepted-already',
-            expires: 600
+            expires: 600,
+            'cookie-path': '/',
+            'close-text': 'noooo!'
         };
         Cookies.set(opts.cookie, 1, opts.expires, opts['cookie-path']);
-
         stop();
         // now testing the actual scenario
         inject_script(script_src, 'cookiebanner', opts, 'body', function(){


### PR DESCRIPTION
- Added an option for customizing the close button text/symbol (see #10)
- added a CSS classname ("cookiebanner-close") to the element containing the close button (which should further help customizations)
- fixed 'data-' options handling which wasn't really working as it should've been (on browsers implementing dataset)
- switched to using camelCase option names within the code (due to the dataset API converting automatically and it being easier to replicate for browsers that don't support dataset)
- avoid "polluting" the global namespace and instantiating Cookiebanner if we're not being invoked in a way that really requires it
- added 2 simple demos within the tests folder for easier manual testing
