### PR TITLE
Fix the (somewhat specific/rare) case of an exception being thrown when ...

### DIFF
--- a/src/cookiebanner.js
+++ b/src/cookiebanner.js
@@ -332,10 +332,10 @@
             if (this.inserted) {
                 if (!this.closed) {
                     if (this.element) {
-                        doc.body.removeChild(this.element);
+                        this.element.parentNode.removeChild(this.element);
                     }
                     if (this.element_mask) {
-                        doc.body.removeChild(this.element_mask);
+                        this.element_mask.parentNode.removeChild(this.element_mask);
                     }
                     this.closed = true;
                 }


### PR DESCRIPTION
...trying to close the banner by using a more robust approach for referencing the nodes that are removed.

Exceptions occur when our cookiebanner div (and/or mask) is moved within the DOM (for whatever reason) between being injected and being closed/removed.

Legit reasons include certain jQuery plugins for mobile navigation or similar...