### PR TITLE
New option `AcceptOnScroll`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ style. The following options are settable through a `data-` property on the
 * `mask-opacity` - the opacity to use for the window mask (default: `0.5`)
 * `mask-background` - optional background style you wish to apply to the `mask` <div> (default: `#000`)
 * `zindex` - z-index to set on the notice (default: `255`). If `mask` is used, the notice <div>'s z-index is automatically incremented by 1 so it appears above the mask)
+* `accept-on-scroll` - when is set `true` window scrolling is considered as acceptance. (default: `false`)
 
 Here's an example:
 

--- a/src/cookiebanner.js
+++ b/src/cookiebanner.js
@@ -241,7 +241,8 @@
                 fontSize: '14px',
                 fontFamily: 'arial, sans-serif',
                 instance: global_instance_name,
-                textAlign: 'center'
+                textAlign: 'center',
+                acceptOnScroll: false
             };
 
             this.options = this.default_options;
@@ -431,6 +432,13 @@
                     self.agree_and_close();
                 });
                 doc.body.appendChild(this.element_mask);
+            }
+
+            // Agree and close banner on window scroll if `acceptOnScroll` option is set `true`
+            if (this.options.acceptOnScroll) {
+              on(window, 'scroll', function(){
+                self.agree_and_close();
+              });
             }
 
             doc.body.appendChild(this.element);


### PR DESCRIPTION
Hi, thank you for the script.

In Italy for the cookie law is considered as acceptance every single interaction of the user with the page, including the window scroll. I've just added an option `AcceptOnScroll` that allows this behaviour. 
If the options is set `true` a listener for the scroll event is added to window.
This option defaults to `false`.