### PR TITLE
Add domain to configurable properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ style. The following options are settable through a `data-` property on the
 * `mask-background` - optional background style you wish to apply to the `mask` <div> (default: `#000`)
 * `zindex` - z-index to set on the notice (default: `255`). If `mask` is used, the notice <div>'s z-index is automatically incremented by 1 so it appears above the mask)
 * `accept-on-scroll` - when is set `true` window scrolling is considered as acceptance. (default: `false`)
+* `domain` - explicitly set domain for cookie. Set to `example.com` to require acceptance once for all subdomains of `example.com` (`*.example.com`)
 
 Here's an example:
 

--- a/src/cookiebanner.js
+++ b/src/cookiebanner.js
@@ -263,7 +263,8 @@ THE SOFTWARE.
                 fontFamily: 'arial, sans-serif',
                 instance: global_instance_name,
                 textAlign: 'center',
-                acceptOnScroll: false
+                acceptOnScroll: false,
+                domain: null
             };
 
             this.options = this.default_options;
@@ -343,7 +344,7 @@ THE SOFTWARE.
         },
 
         agree: function() {
-            this.cookiejar.set(this.options.cookie, 1, this.options.expires, this.options.cookiePath);
+            this.cookiejar.set(this.options.cookie, 1, this.options.expires, this.options.cookiePath, this.options.domain);
             return true;
         },
 


### PR DESCRIPTION
Now you can add `domain` to the data properties of `script` as well:

``` html
<script type="text/javascript" id="cookiebanner"
        src="cookiebanner.js"
        data-domain="example.com">
</script>
```
