### PR TITLE
Make sure font size of moreinfo link is same as message

### DIFF
--- a/src/cookiebanner.js
+++ b/src/cookiebanner.js
@@ -443,6 +443,7 @@ THE SOFTWARE.
             el_a.style.textDecoration = this.options.moreinfoDecoration;
             el_a.style.color = this.options.link;
             el_a.style.fontWeight = this.options.moreinfoFontWeight;
+            el_a.style.fontSize = this.options.fontSize;
 
             var el_x = el.getElementsByTagName('div')[0];
             el_x.style.cursor = 'pointer';

--- a/src/cookiebanner.js
+++ b/src/cookiebanner.js
@@ -264,6 +264,7 @@ THE SOFTWARE.
                 moreinfoTarget: '_blank',
                 moreinfoDecoration: 'none',
                 moreinfoFontWeight: 'normal',
+                moreinfoFontSize: null,
                 effect: null,
                 fontSize: '14px',
                 fontFamily: 'arial, sans-serif',
@@ -443,8 +444,10 @@ THE SOFTWARE.
             el_a.style.textDecoration = this.options.moreinfoDecoration;
             el_a.style.color = this.options.link;
             el_a.style.fontWeight = this.options.moreinfoFontWeight;
-            el_a.style.fontSize = this.options.fontSize;
-
+            if(this.options.moreinfoFontSize !== '') {
+                el_a.style.fontSize = this.options.moreinfoFontSize;
+            }
+		
             var el_x = el.getElementsByTagName('div')[0];
             el_x.style.cursor = 'pointer';
 


### PR DESCRIPTION
el_a.style.fontSize = this.options.fontSize;

I implemented cookie-banner on a website and noticed the font size of the "more info" link was bigger than the message (due to website CSS style), so adding this change should make sure the font size of the "more info" link is same as the font size specified in the options.