### PR TITLE
add option closePrecedes to allow close text to follow the message fo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 ### Added
-- n/a
+- New option: `closePrecedes` (default `true` allows `cookiebanner-close` follow the `span` element with the message)
 
 ### Changed
 - n/a

--- a/src/cookiebanner.js
+++ b/src/cookiebanner.js
@@ -245,6 +245,7 @@ THE SOFTWARE.
                 cookie: 'cookiebanner-accepted',
                 closeText: '&#10006;',
                 closeStyle: 'float:right;padding-left:5px;',
+                closePrecedes: true,
                 cookiePath: '/',
                 cookieDomain: null,
                 cookieSecure: false,
@@ -437,9 +438,20 @@ THE SOFTWARE.
                 el.style.bottom = 0;
             }
 
-            el.innerHTML = '<div class="cookiebanner-close" style="' + this.options.closeStyle + '">' +
-                this.options.closeText + '</div>' +
-                '<span>' + this.options.message + (this.options.linkmsg ? ' <a>' + this.options.linkmsg + '</a>' : '') + '</span>';
+
+            var closeHtml = '<div class="cookiebanner-close" style="' + this.options.closeStyle + '">' +
+                this.options.closeText + '</div>';
+            var messageHtml = '<span>' + this.options.message + (this.options.linkmsg ? ' <a>' + this.options.linkmsg + '</a>' : '') + '</span>';
+
+            if ( this.options.closePrecedes == 'false' )
+            {
+              el.innerHTML = messageHtml + closeHtml;
+            }
+            else
+            {
+              el.innerHTML = closeHtml + messageHtml;
+            }
+
 
             this.element = el;
 

--- a/src/cookiebanner.js
+++ b/src/cookiebanner.js
@@ -443,7 +443,7 @@ THE SOFTWARE.
                 this.options.closeText + '</div>';
             var messageHtml = '<span>' + this.options.message + (this.options.linkmsg ? ' <a>' + this.options.linkmsg + '</a>' : '') + '</span>';
 
-            if ( this.options.closePrecedes == 'false' )
+            if ( this.options.closePrecedes === 'false' )
             {
               el.innerHTML = messageHtml + closeHtml;
             }


### PR DESCRIPTION
Allow an option to have the close text follow the cookie message. An example usage would be: 

	<script data-close-precedes="false"
	        data-close-text="I got it."
	        data-close-style="display:inline;text-decoration:underline;"
	        data-linkmsg=" "
	        ...