### PR TITLE
sleepBeforeClose and Utils.sleep(milliseconds)

### DIFF
--- a/src/cookiebanner.js
+++ b/src/cookiebanner.js
@@ -132,6 +132,15 @@ THE SOFTWARE.
             }
             return obj;
         },
+        
+        sleep: function(milliseconds) {
+            var start = new Date().getTime();
+            for (var i = 0; i < 1e7; i++) {
+                if ((new Date().getTime() - start) > milliseconds){
+                    break;
+                }
+            }
+        },
 
         str2bool: function(str) {
             str = String(str);
@@ -276,7 +285,8 @@ THE SOFTWARE.
                 acceptOnScroll: false,
                 acceptOnClick: false,
                 acceptOnTimeout: null,
-                acceptOnFirstVisit: false
+                acceptOnFirstVisit: false,
+                sleepBeforeClose: null
             };
 
             this.options = this.default_options;
@@ -387,6 +397,9 @@ THE SOFTWARE.
         agree_and_close:function() {
             if (!this.options.debug) {
                 this.agree();
+            }
+            if (this.options.sleepBeforeClose && !isNaN(parseFloat(this.options.sleepBeforeClose)) && isFinite(this.options.sleepBeforeClose)) {
+                    Utils.sleep(this.options.sleepBeforeClose);
             }
             return this.close();
         },

--- a/src/cookiebanner.js
+++ b/src/cookiebanner.js
@@ -132,15 +132,6 @@ THE SOFTWARE.
             }
             return obj;
         },
-        
-        sleep: function(milliseconds) {
-            var start = new Date().getTime();
-            for (var i = 0; i < 1e7; i++) {
-                if ((new Date().getTime() - start) > milliseconds){
-                    break;
-                }
-            }
-        },
 
         str2bool: function(str) {
             str = String(str);
@@ -399,9 +390,11 @@ THE SOFTWARE.
                 this.agree();
             }
             if (this.options.sleepBeforeClose && !isNaN(parseFloat(this.options.sleepBeforeClose)) && isFinite(this.options.sleepBeforeClose)) {
-                    Utils.sleep(this.options.sleepBeforeClose);
+                var self_ = this;
+                setTimeout(function() { self_.close(); }, this.options.sleepBeforeClose);
+            } else {
+                return this.close();
             }
-            return this.close();
         },
 
         // close and remove every trace of ourselves completely


### PR DESCRIPTION
Allows to set a sleep(milliseconds) before closing the cookie banner, example:

```
  <script type="text/javascript" id="cookiebanner"
      src="../src/cookiebanner.js"
      data-height="20px"
      data-close-text="NOooo!"
	  data-font-size="16px"
	  data-accept-on-click="true"
	  data-effect="fade"
	  data-sleep-before-close="1000"
      data-message="We use cookies to improve your browsing experience.">
  </script>
```

Useful to use with `accept-on-scroll` and `accept-on-click`, so the banner will wait (sleep) N milliseconds before being closed after an user has scrolled the page (accept-on-scroll) or triggered the onclick-event (accept-on-click).