### PR TITLE
Updated information about data-effect="fade"

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ style. The following options are settable through a `data-` property on the
 * `font-size` - Text/font size for the .cookiebanner (container) element (default: `14px`)
 * `font-family` - Font family for the .cookiebanner (container) element (default: `arial, sans-serif`)
 * `text-align` - Text align/position for the .cookiebanner (container) element (default: `center`)
-* `effect` - Effect used when inserting the notice, currently only `fade` supported (default: `null`)
+* `effect` - Effect used when inserting the notice, currently only `fade` is supported (triggered when cookiebanner is displayed and when it is closed) (default: `null`)
 * `cookie` - Name for the cookie that stores acceptance info (default: `cookiebanner-accepted`)
 * `expires` - Cookie expiry date/time (defaults to `Infinity` aka `Fri, 31 Dec 9999 23:59:59 GMT`). There's basic support for specifying a callback function (more flexibility, must return one of `Number`, `String`, or `Date` -- see `Cookies.set()`). You can also just specify a valid UTC string.
 * `cookie-path` - Path to set for the cookie


### PR DESCRIPTION
Included information about PR https://github.com/dobarkod/cookie-banner/pull/70:

* `effect` - Effect used when inserting the notice, currently only `fade` is supported (triggered when cookiebanner is displayed and when it is closed) (default: `null`)